### PR TITLE
Add rest-config to the kubernetes client

### DIFF
--- a/pkg/kube/main.go
+++ b/pkg/kube/main.go
@@ -23,6 +23,7 @@ type KubernetesClient struct {
 	Client          kubernetes.Interface
 	DynClient       dynamic.Interface
 	DiscoveryClient *discovery.DiscoveryClient
+	config          *rest.Config
 }
 
 // Init initializes the Kubernetes client-go.
@@ -47,6 +48,9 @@ func (kc *KubernetesClient) Init() error {
 	if err != nil {
 		return err
 	}
+
+	kc.config = config
+
 	// return k8s client and err
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
@@ -70,6 +74,11 @@ func (kc *KubernetesClient) Init() error {
 	kc.DiscoveryClient = dis
 
 	return nil
+}
+
+// Config returns the rest configuration to the Kubernetes API.
+func (kc *KubernetesClient) Config() *rest.Config {
+	return kc.config
 }
 
 func (kc *KubernetesClient) inClusterConfig() (*rest.Config, error) {


### PR DESCRIPTION
Another requirement found while developing CRD stuff. It exposes the configuration used to generate the clients