### PR TITLE
Add job related shared functions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -20,6 +20,8 @@ steps:
         apk add make bash util-linux
       - &target
         make $${DRONE_STEP_NAME}
+      - &clean-target
+        make clean-$${DRONE_STEP_NAME}
 
   - <<: *docker-test
     name: lint

--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,7 @@ test: check-docker
 ## license: Check license headers are in-place in all files in the project
 license: check-docker
 	@docker build --no-cache --pull --target license -f build/builder/Dockerfile -t ${PROJECTNAME}:local-license .
+
+## clean-%: Clean the container image resulting from another target. make build clean-build
+clean-%:
+	@docker rmi -f ${PROJECTNAME}:local-${*}

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/sighupio/fip-commons
 go 1.16
 
 require (
-	k8s.io/api v0.18.14 // indirect
-	k8s.io/apimachinery v0.18.14 // indirect
+	k8s.io/api v0.18.14
+	k8s.io/apimachinery v0.18.14
 	k8s.io/client-go v0.18.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,7 @@ github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEo
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -83,8 +84,10 @@ github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8m
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.11.0 h1:JAKSXpt1YjtLA7YpPiqO9ss6sNXEsPfSGdwN0UHqzrw=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
+github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
@@ -160,9 +163,11 @@ google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZi
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/kube/jobs/jobs.go
+++ b/pkg/kube/jobs/jobs.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2021 SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package jobs
 
 import (

--- a/pkg/kube/jobs/jobs.go
+++ b/pkg/kube/jobs/jobs.go
@@ -1,0 +1,30 @@
+package jobs
+
+import (
+	"context"
+
+	"github.com/sighupio/fip-commons/pkg/kube"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// GetPodsfromJob returns a list of Pods from a specific job.
+func GetPodsfromJob(ctx context.Context, kc *kube.KubernetesClient, job batchv1.Job) ([]corev1.Pod, error) {
+	labelSelector := v1.LabelSelector{MatchLabels: map[string]string{"job-name": job.Name}}
+	podList, err := kc.Client.CoreV1().Pods(job.Namespace).List(ctx, v1.ListOptions{
+		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
+		Limit:         int64(*job.Spec.BackoffLimit),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(podList.Items) > 0 {
+		return podList.Items, nil
+	}
+
+	return make([]corev1.Pod, 0), nil
+}

--- a/pkg/kube/jobs/jobs_test.go
+++ b/pkg/kube/jobs/jobs_test.go
@@ -1,0 +1,103 @@
+package jobs
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/sighupio/fip-commons/pkg/kube"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetPodsfromJob(t *testing.T) {
+	backoff := int32(4)
+	podObj := &corev1.Pod{ObjectMeta: v1.ObjectMeta{Name: "hello-12345", Namespace: "default", Labels: map[string]string{"job-name": "hello"}}}
+	type args struct {
+		ctx context.Context
+		kc  *kube.KubernetesClient
+		job batchv1.Job
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []corev1.Pod
+		wantErr bool
+	}{
+		{
+			name: "Empty List",
+			args: args{
+				ctx: context.TODO(),
+				kc: &kube.KubernetesClient{
+					Client: fake.NewSimpleClientset(),
+				},
+				job: batchv1.Job{
+					TypeMeta: v1.TypeMeta{},
+					ObjectMeta: v1.ObjectMeta{
+						Name: "demo",
+					},
+					Spec: batchv1.JobSpec{
+						BackoffLimit: &backoff,
+					},
+					Status: batchv1.JobStatus{},
+				},
+			},
+			want:    []corev1.Pod{},
+			wantErr: false,
+		}, {
+			name: "One Pod",
+			args: args{
+				ctx: context.TODO(),
+				kc: &kube.KubernetesClient{
+					Client: fake.NewSimpleClientset(podObj),
+				},
+				job: batchv1.Job{
+					TypeMeta: v1.TypeMeta{},
+					ObjectMeta: v1.ObjectMeta{
+						Name: "hello",
+					},
+					Spec: batchv1.JobSpec{
+						BackoffLimit: &backoff,
+					},
+					Status: batchv1.JobStatus{},
+				},
+			},
+			want:    []corev1.Pod{*podObj},
+			wantErr: false,
+		}, {
+			name: "No Pods",
+			args: args{
+				ctx: context.TODO(),
+				kc: &kube.KubernetesClient{
+					Client: fake.NewSimpleClientset(podObj),
+				},
+				job: batchv1.Job{
+					TypeMeta: v1.TypeMeta{},
+					ObjectMeta: v1.ObjectMeta{
+						Name: "bye",
+					},
+					Spec: batchv1.JobSpec{
+						BackoffLimit: &backoff,
+					},
+					Status: batchv1.JobStatus{},
+				},
+			},
+			want:    []corev1.Pod{},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetPodsfromJob(tt.args.ctx, tt.args.kc, tt.args.job)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetPodsfromJob() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetPodsfromJob() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/kube/jobs/jobs_test.go
+++ b/pkg/kube/jobs/jobs_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2021 SIGHUP s.r.l All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package jobs
 
 import (

--- a/pkg/kube/main.go
+++ b/pkg/kube/main.go
@@ -17,6 +17,14 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+const (
+	// KfipBaseLabel use this label as base of other labels like check or group.
+	KfipBaseLabel = "kfip.sighup.io"
+
+	// AppBaseLabel use this label as base of other labels like name or component.
+	AppBaseLabel = "app.kubernetes.io"
+)
+
 // KubernetesClient represents the Kubernetes configuration of the project.
 type KubernetesClient struct {
 	KubeConfig      string


### PR DESCRIPTION
In this PR you will find:

- A new package and function to query pods from a job
- Two new constants that we will use across multiple go projects
- Add the "cleanup" feature added days ago in the project template
- Refactor some docs (outdated)

Thanks